### PR TITLE
Reset backup domain in test initialization

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -627,3 +627,16 @@ pub fn set_mco(pin: gpio::GpioPort, clk: Mcosel, div: stm32_metapac::rcc::vals::
         w.set_mcopre(div);
     });
 }
+
+pub fn reset_backup_domain() {
+    // enable backup domain write
+    RCC.ahb3enr().modify(|v| v.set_pwren(true));
+    PWR.dbpcr().modify(|v| v.set_dbp(true));
+
+    RCC.bdcr().modify(|v| v.set_bdrst(true));
+    delay_tick(100);
+    RCC.bdcr().modify(|v| v.set_bdrst(false));
+
+    // disable backup domain write
+    PWR.dbpcr().modify(|v| v.set_dbp(false));
+}

--- a/tests/clock.rs
+++ b/tests/clock.rs
@@ -20,6 +20,7 @@ mod tests {
     #[init]
     fn init() {
         // u5_lib::clock::init_clock(true, clock::ClockFreqs::KernelFreq160Mhz);
+        u5_lib::clock::reset_backup_domain();
     }
 
     #[test]

--- a/tests/exti_btn.rs
+++ b/tests/exti_btn.rs
@@ -13,6 +13,7 @@ mod tests {
     #[init]
     fn init() {
         // u5_lib::clock::init_clock(true, clock::ClockFreqs::KernelFreq160Mhz);
+        u5_lib::clock::reset_backup_domain();
     }
 
     #[test]

--- a/tests/gpio.rs
+++ b/tests/gpio.rs
@@ -14,6 +14,7 @@ mod tests {
     #[init]
     fn init() {
         // u5_lib::clock::init_clock(true, clock::ClockFreqs::KernelFreq160Mhz);
+        u5_lib::clock::reset_backup_domain();
     }
 
     #[test]

--- a/tests/panic.rs
+++ b/tests/panic.rs
@@ -12,6 +12,7 @@ mod tests {
     #[init]
     fn init() {
         // u5_lib::clock::init_clock(true, clock::ClockFreqs::KernelFreq160Mhz);
+        u5_lib::clock::reset_backup_domain();
     }
 
     #[test]

--- a/tests/rtc.rs
+++ b/tests/rtc.rs
@@ -17,6 +17,7 @@ mod tests {
     #[init]
     fn init() {
         // u5_lib::clock::init_clock(true, clock::ClockFreqs::KernelFreq160Mhz);
+        u5_lib::clock::reset_backup_domain();
     }
 
     #[test]

--- a/tests/tim.rs
+++ b/tests/tim.rs
@@ -18,6 +18,7 @@ mod tests {
     #[init]
     fn init() {
         // u5_lib::clock::init_clock(true, clock::ClockFreqs::KernelFreq160Mhz);
+        u5_lib::clock::reset_backup_domain();
     }
 
     #[test]


### PR DESCRIPTION
This change introduces a `reset_backup_domain` function in `src/clock.rs` that performs a software reset of the backup domain (BDRST). This function is then called at the beginning of each integration test (in the `#[init]` function) to ensure a clean state for the backup domain peripherals (like RTC) before each test run. This fixes an issue where multiple tests running in sequence would fail due to persistent state in the backup domain.

---
*PR created automatically by Jules for task [15965077232198371024](https://jules.google.com/task/15965077232198371024) started by @chen-gz*