### PR TITLE
Add async `timeout` function with cancellation safety

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -330,7 +330,8 @@ pub fn init_clock(
     unsafe {
         // this is safe because this function should only be called once
         if CALLED {
-            panic!("init_clock_new should only be called once");
+            info!("init_clock called again, ignoring");
+            return;
         }
         CALLED = true;
     }


### PR DESCRIPTION
This PR introduces a robust `timeout` function for async operations using the `Lptim` hardware timer.

Key changes:
1.  **`timeout` Function**: A new async function `timeout(lptim, duration, future)` is added to `src/lptim.rs`. It races the provided future against a timer delay.
2.  **`LptimDelay` Future**: The internal delay mechanism (`after_limit`) was refactored to return a custom `LptimDelay` struct that implements `Future`. Crucially, it implements `Drop` to safely disable the hardware timer and release the `TIMER_LOCKER` if the future is dropped (e.g., due to timeout or cancellation), preventing resource leaks and spurious interrupts.
3.  **Idempotent `init_clock`**: The `clock::init_clock` function was modified to return early if called multiple times, preventing panics during sequential test execution where `init` might be called repeatedly.
4.  **Testing**: A new test case `test_timeout` was added to `tests/lptim.rs` to verify the timeout functionality and successful completion scenarios.

The implementation relies on `futures::future::select` and requires the `nucleo_u575` (or similar) feature to be enabled for tests.

---
*PR created automatically by Jules for task [11578679362171238578](https://jules.google.com/task/11578679362171238578) started by @chen-gz*