### PR TITLE
feat(i2c): implement I2C slave support and async interrupt-driven I2C

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,3 +171,7 @@ harness = false
 [[test]]
 name = "usb_cdc_acm"
 harness = false
+
+[[test]]
+name = "i2c"
+harness = false

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -183,10 +183,10 @@ define_gpio_port_alt!(
     TIM3_CH1_PB4: GPIOB, 4, 2, Moder::ALTERNATE, Ot::PUSH_PULL, Pupdr::FLOATING,
     TIM3_CH4_PB1: GPIOB, 1, 2, Moder::ALTERNATE, Ot::PUSH_PULL, Pupdr::FLOATING
 );
-pub const I2C1_SCL_PINS: [GpioPort; 3] = [I2C1_SCL_PB6, I2C1_SCL_PB8, I2C2_SCL_PB10];
+pub const I2C1_SCL_PINS: [GpioPort; 2] = [I2C1_SCL_PB6, I2C1_SCL_PB8];
 pub const I2C1_SDA_PINS: [GpioPort; 3] = [I2C1_SDA_PB3, I2C1_SDA_PB7, I2C1_SDA_PB9];
-pub const I2C2_SCL_PINS: [GpioPort; 2] = [I2C2_SCL_PB13, I2C2_SCL_PF1];
-pub const I2C2_SDA_PINS: [GpioPort; 2] = [I2C2_SDA_PB14, I2C2_SDA_PF0];
+pub const I2C2_SCL_PINS: [GpioPort; 3] = [I2C2_SCL_PB13, I2C2_SCL_PF1, I2C2_SCL_PB10];
+pub const I2C2_SDA_PINS: [GpioPort; 3] = [I2C2_SDA_PB14, I2C2_SDA_PF0, I2C2_SDA_PB11];
 pub const I2C3_SCL_PINS: [GpioPort; 1] = [I2C3_SCL_PC0];
 pub const I2C3_SDA_PINS: [GpioPort; 1] = [I2C3_SDA_PB4];
 pub const USART1_TX_PINS: [GpioPort; 1] = [USART_TX_PA9];

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,9 +1,14 @@
 #![allow(unused)]
 
 use crate::clock;
+use core::task::Poll;
+use cortex_m::peripheral::NVIC;
+use embassy_sync::waitqueue::AtomicWaker;
+use stm32_metapac::interrupt;
 use stm32_metapac::{I2C1, RCC};
 
 static mut TAKEN: [bool; 8] = [false; 8]; // first bit will be ignored
+static WAKERS: [AtomicWaker; 8] = [const { AtomicWaker::new() }; 8];
 
 #[derive(Copy, Clone, Debug)]
 pub enum I2cError {
@@ -28,6 +33,7 @@ pub struct I2cConfig {
 pub struct I2c {
     port_num: u8,
     port: stm32_metapac::i2c::I2c,
+    freq: hal::I2cFrequency,
 }
 
 impl I2cConfig {
@@ -87,6 +93,205 @@ pub fn pin_to_port(scl_pin: &GpioPort, sda_pin: &GpioPort) -> u8 {
 //     }
 // }
 
+impl I2c {
+    pub async fn write_async_interrupt(&self, addr: u16, data: &[u8]) -> Result<(), hal::I2cError> {
+        assert!(data.len() <= 255);
+        self.port.cr2().modify(|v| {
+            v.set_sadd(addr << 1);
+            v.set_nbytes(data.len() as u8);
+            v.set_dir(stm32_metapac::i2c::vals::Dir::WRITE);
+            v.set_start(true);
+        });
+
+        for &byte in data {
+            core::future::poll_fn(|cx| {
+                WAKERS[self.port_num as usize].register(cx.waker());
+                self.port.cr1().modify(|v| {
+                    v.set_txie(true);
+                    v.set_nackie(true);
+                });
+                let isr = self.port.isr().read();
+                if isr.nackf() {
+                    Poll::Ready(Err(hal::I2cError::Nack))
+                } else if isr.txis() {
+                    Poll::Ready(Ok(()))
+                } else {
+                    Poll::Pending
+                }
+            })
+            .await?;
+            self.port.txdr().write(|v| v.set_txdata(byte));
+        }
+
+        core::future::poll_fn(|cx| {
+            WAKERS[self.port_num as usize].register(cx.waker());
+            self.port.cr1().modify(|v| {
+                v.set_tcie(true);
+                v.set_stopie(true);
+                v.set_nackie(true);
+            });
+            let isr = self.port.isr().read();
+            if isr.nackf() {
+                Poll::Ready(Err(hal::I2cError::Nack))
+            } else if isr.stopf() || isr.tc() {
+                Poll::Ready(Ok(()))
+            } else {
+                Poll::Pending
+            }
+        })
+        .await?;
+
+        self.port.icr().write(|v| {
+            v.set_stopcf(true);
+            v.set_nackcf(true);
+        });
+
+        Ok(())
+    }
+
+    pub async fn read_async_interrupt(&self, addr: u16, data: &mut [u8]) -> Result<(), hal::I2cError> {
+        assert!(data.len() <= 255);
+        self.port.cr2().modify(|v| {
+            v.set_sadd(addr << 1);
+            v.set_nbytes(data.len() as u8);
+            v.set_dir(stm32_metapac::i2c::vals::Dir::READ);
+            v.set_start(true);
+        });
+
+        for i in 0..data.len() {
+            core::future::poll_fn(|cx| {
+                WAKERS[self.port_num as usize].register(cx.waker());
+                self.port.cr1().modify(|v| {
+                    v.set_rxie(true);
+                    v.set_nackie(true);
+                });
+                let isr = self.port.isr().read();
+                if isr.nackf() {
+                    Poll::Ready(Err(hal::I2cError::Nack))
+                } else if isr.rxne() {
+                    Poll::Ready(Ok(()))
+                } else {
+                    Poll::Pending
+                }
+            })
+            .await?;
+            data[i] = self.port.rxdr().read().rxdata();
+        }
+
+        core::future::poll_fn(|cx| {
+            WAKERS[self.port_num as usize].register(cx.waker());
+            self.port.cr1().modify(|v| {
+                v.set_tcie(true);
+                v.set_stopie(true);
+                v.set_nackie(true);
+            });
+            let isr = self.port.isr().read();
+            if isr.nackf() {
+                Poll::Ready(Err(hal::I2cError::Nack))
+            } else if isr.stopf() || isr.tc() {
+                Poll::Ready(Ok(()))
+            } else {
+                Poll::Pending
+            }
+        })
+        .await?;
+
+        self.port.icr().write(|v| {
+            v.set_stopcf(true);
+            v.set_nackcf(true);
+        });
+
+        Ok(())
+    }
+
+    pub async fn wait_address_async_interrupt(&self) -> Result<hal::I2cSlaveEvent, hal::I2cError> {
+        core::future::poll_fn(|cx| {
+            WAKERS[self.port_num as usize].register(cx.waker());
+            self.port.cr1().modify(|v| {
+                v.set_addrie(true);
+            });
+            let isr = self.port.isr().read();
+            if isr.addr() {
+                let dir = isr.dir();
+                // Clear ADDR flag by writing to ADDRCF in ICR
+                self.port.icr().write(|v| v.set_addrcf(true));
+                if dir == stm32_metapac::i2c::vals::Dir::READ {
+                    Poll::Ready(Ok(hal::I2cSlaveEvent::Read))
+                } else {
+                    Poll::Ready(Ok(hal::I2cSlaveEvent::Write))
+                }
+            } else {
+                Poll::Pending
+            }
+        })
+        .await
+    }
+
+    pub async fn read_async_slave(&self, data: &mut [u8]) -> Result<(), hal::I2cError> {
+        for i in 0..data.len() {
+            core::future::poll_fn(|cx| {
+                WAKERS[self.port_num as usize].register(cx.waker());
+                self.port.cr1().modify(|v| {
+                    v.set_rxie(true);
+                    v.set_stopie(true);
+                });
+                let isr = self.port.isr().read();
+                if isr.rxne() {
+                    Poll::Ready(Ok(()))
+                } else if isr.stopf() {
+                    // Host sent STOP before we read all data
+                    Poll::Ready(Err(hal::I2cError::BusError))
+                } else {
+                    Poll::Pending
+                }
+            })
+            .await?;
+            data[i] = self.port.rxdr().read().rxdata();
+        }
+        // Clear STOPF if it was set
+        self.port.icr().write(|v| v.set_stopcf(true));
+        Ok(())
+    }
+
+    pub async fn write_async_slave(&self, data: &[u8]) -> Result<(), hal::I2cError> {
+        for &byte in data {
+            core::future::poll_fn(|cx| {
+                WAKERS[self.port_num as usize].register(cx.waker());
+                self.port.cr1().modify(|v| {
+                    v.set_txie(true);
+                    v.set_stopie(true);
+                });
+                let isr = self.port.isr().read();
+                if isr.txis() {
+                    Poll::Ready(Ok(()))
+                } else if isr.stopf() {
+                    Poll::Ready(Err(hal::I2cError::BusError))
+                } else {
+                    Poll::Pending
+                }
+            })
+            .await?;
+            self.port.txdr().write(|v| v.set_txdata(byte));
+        }
+        // Wait for TC or STOP
+        core::future::poll_fn(|cx| {
+            WAKERS[self.port_num as usize].register(cx.waker());
+            self.port.cr1().modify(|v| {
+                v.set_stopie(true);
+            });
+            let isr = self.port.isr().read();
+            if isr.stopf() {
+                Poll::Ready(Ok(()))
+            } else {
+                Poll::Pending
+            }
+        })
+        .await?;
+        self.port.icr().write(|v| v.set_stopcf(true));
+        Ok(())
+    }
+}
+
 pub struct I2cMessage<'a> {
     pub addr: u16,
     pub data: &'a mut [u8],
@@ -95,13 +300,13 @@ pub struct I2cMessage<'a> {
 /////////////////////////// HAL implementation /////////////////////////////
 use crate::gpio::{
     GpioPort, I2C1_SCL_PB6, I2C1_SCL_PB8, I2C1_SCL_PINS, I2C1_SDA_PB7, I2C1_SDA_PINS, I2C2_SCL_PF1, I2C2_SCL_PINS, I2C2_SDA_PINS,
-    I2C3_SCL_PINS, I2C3_SDA_PB4, I2C3_SDA_PINS, PB4,
+    I2C3_SCL_PINS, I2C3_SDA_PB4, I2C3_SDA_PINS, PB4, I2C2_SCL_PB13, I2C2_SDA_PB14,
 };
 use crate::hal;
 impl hal::I2c<GpioPort> for I2c {
     fn new(freq: hal::I2cFrequency, sda_pin: GpioPort, scl_pin: GpioPort) -> Result<Self, hal::I2cError> {
         let port_num = pin_to_port(&scl_pin, &sda_pin);
-        let freq = match freq {
+        let freq_val = match freq {
             hal::I2cFrequency::Freq100khz => 100_000,
             hal::I2cFrequency::Freq400khz => 400_000,
             hal::I2cFrequency::Freq1Mhz => 1_000_000,
@@ -127,11 +332,11 @@ impl hal::I2c<GpioPort> for I2c {
         // TODO: HSI 16 is used as system clock for easy setup.
         // The values are from the reference menu
         // set as 100Khz
-        let (presc, scll, sclh, sdadel, scldel) = match freq {
+        let (presc, scll, sclh, sdadel, scldel) = match freq_val {
             10_000 => (3, 0xC7, 0xC3, 0x2, 0x4), // 10khz
             100_000 => (3, 0x13, 0xF, 0x2, 0x4),  // 100khz
             400_000 => (1, 9, 3, 2, 3),          // 400khz
-            
+            1_000_000 => (0, 9, 4, 1, 2),        // 1Mhz
             _ => panic!("invalid frequency"),
         };
         port.timingr().modify(|v| {
@@ -157,7 +362,28 @@ impl hal::I2c<GpioPort> for I2c {
             v.set_pe(true);
         });
         clock::delay_tick(10);
-        Ok(I2c { port, port_num })
+        unsafe {
+            match port_num {
+                1 => {
+                    NVIC::unmask(interrupt::I2C1_EV);
+                    NVIC::unmask(interrupt::I2C1_ER);
+                }
+                2 => {
+                    NVIC::unmask(interrupt::I2C2_EV);
+                    NVIC::unmask(interrupt::I2C2_ER);
+                }
+                3 => {
+                    NVIC::unmask(interrupt::I2C3_EV);
+                    NVIC::unmask(interrupt::I2C3_ER);
+                }
+                4 => {
+                    NVIC::unmask(interrupt::I2C4_EV);
+                    NVIC::unmask(interrupt::I2C4_ER);
+                }
+                _ => {}
+            }
+        }
+        Ok(I2c { port, port_num, freq })
     }
 
     fn write(&self, addr: u16, data: &[u8]) -> Result<(), hal::I2cError> {
@@ -166,7 +392,7 @@ impl hal::I2c<GpioPort> for I2c {
         //       id not allowed, return error.
         // set slave address
         self.port.cr2().modify(|v| {
-            v.set_sadd(addr);
+            v.set_sadd(addr << 1);
             v.set_nbytes(data.len() as u8);
             v.set_dir(stm32_metapac::i2c::vals::Dir::WRITE);
             v.set_start(true);
@@ -192,9 +418,7 @@ impl hal::I2c<GpioPort> for I2c {
     //     todo!( "not implement")
     // }
     fn read_async(&self, addr: u16, data: &mut [u8]) -> impl core::future::Future<Output = Result<(), hal::I2cError>> + Send {
-        async move {
-            todo!("Implement data fetching logic here");
-        }
+        self.read_async_interrupt(addr, data)
     }
 
     fn read(&self, addr: u16, data: &mut [u8]) -> Result<(), hal::I2cError> {
@@ -203,7 +427,7 @@ impl hal::I2c<GpioPort> for I2c {
         // todo: check hardware status. Whether it allows to send data.
         // todo: id not allowed, return error.
         self.port.cr2().modify(|v| {
-            v.set_sadd(addr);
+            v.set_sadd(addr << 1);
             v.set_nbytes(data.len() as u8);
             v.set_dir(stm32_metapac::i2c::vals::Dir::READ);
             v.set_start(true);
@@ -223,25 +447,221 @@ impl hal::I2c<GpioPort> for I2c {
 
     // }
     fn write_async(&self, addr: u16, data: &[u8]) -> impl core::future::Future<Output = Result<(), hal::I2cError>> + Send {
-        async move {
-            todo!("Implement data sending logic here");
-        }
+        self.write_async_interrupt(addr, data)
     }
 
     fn write_read(&self, addr: u16, write_data: &[u8], read_data: &mut [u8]) -> Result<(), hal::I2cError> {
-        let message = I2cMessage { addr, data: read_data };
         assert!(write_data.len() <= 255);
         assert!(read_data.len() <= 255);
-        self.write(addr, write_data)?;
-        self.read(addr, read_data)?;
+
+        // 1. Write part (no STOP)
+        self.port.cr2().modify(|v| {
+            v.set_sadd(addr << 1);
+            v.set_nbytes(write_data.len() as u8);
+            v.set_dir(stm32_metapac::i2c::vals::Dir::WRITE);
+            v.set_autoend(stm32_metapac::i2c::vals::Autoend::SOFTWARE);
+            v.set_start(true);
+        });
+
+        for &byte in write_data {
+            while !self.port.isr().read().txis() {}
+            self.port.txdr().write(|v| v.set_txdata(byte));
+        }
+
+        // Wait for Transfer Complete (TC)
+        while !self.port.isr().read().tc() {}
+
+        // 2. Read part (with STOP)
+        self.port.cr2().modify(|v| {
+            v.set_sadd(addr << 1);
+            v.set_nbytes(read_data.len() as u8);
+            v.set_dir(stm32_metapac::i2c::vals::Dir::READ);
+            v.set_autoend(stm32_metapac::i2c::vals::Autoend::AUTOMATIC);
+            v.set_start(true);
+        });
+
+        for byte in read_data {
+            while !self.port.isr().read().rxne() {}
+            *byte = self.port.rxdr().read().rxdata();
+        }
+
+        // Wait for STOP
+        while !self.port.isr().read().stopf() {}
+        self.port.icr().write(|v| v.set_stopcf(true));
+
         Ok(())
     }
 
     fn capacity(&self) -> hal::I2cFrequency {
-        todo!()
+        self.freq
     }
 
     // fn write_retry(&self, addr: u16, data: &[u8], retry: u8) -> Result<(), hal::I2cError> {
     //     todo!()
     // }
+}
+
+impl hal::I2cSlave<GpioPort> for I2c {
+    fn new_slave(sda_pin: GpioPort, scl_pin: GpioPort, addr: u16) -> Result<Self, hal::I2cError> {
+        let port_num = pin_to_port(&scl_pin, &sda_pin);
+        unsafe {
+            if { TAKEN[port_num as usize] } {
+                return Err(hal::I2cError::InitError);
+            }
+            TAKEN[port_num as usize] = true;
+        }
+        scl_pin.setup();
+        sda_pin.setup();
+        clock::set_i2c_clock(port_num);
+        let port = port_num_to_i2c(port_num);
+
+        port.cr1().modify(|v| v.set_pe(false));
+        clock::delay_tick(6);
+
+        // Set Own Address 1
+        port.oar1().modify(|v| {
+            v.set_oa1(addr << 1);
+            v.set_oa1en(true);
+        });
+
+        // set autoend to false for slave (usually)
+        port.cr2()
+            .modify(|v| v.set_autoend(stm32_metapac::i2c::vals::Autoend::SOFTWARE));
+
+        port.cr1().modify(|v| {
+            v.set_nostretch(false); // Enable stretching for slave
+            v.set_anfoff(false);
+            v.set_pe(true);
+        });
+        clock::delay_tick(10);
+
+        unsafe {
+            match port_num {
+                1 => {
+                    NVIC::unmask(interrupt::I2C1_EV);
+                    NVIC::unmask(interrupt::I2C1_ER);
+                }
+                2 => {
+                    NVIC::unmask(interrupt::I2C2_EV);
+                    NVIC::unmask(interrupt::I2C2_ER);
+                }
+                3 => {
+                    NVIC::unmask(interrupt::I2C3_EV);
+                    NVIC::unmask(interrupt::I2C3_ER);
+                }
+                4 => {
+                    NVIC::unmask(interrupt::I2C4_EV);
+                    NVIC::unmask(interrupt::I2C4_ER);
+                }
+                _ => {}
+            }
+        }
+
+        Ok(I2c { port, port_num, freq: hal::I2cFrequency::Freq100khz })
+    }
+
+    fn slave_wait_address(&self) -> Result<hal::I2cSlaveEvent, hal::I2cError> {
+        while !self.port.isr().read().addr() {}
+        let isr = self.port.isr().read();
+        let dir = isr.dir();
+        self.port.icr().write(|v| v.set_addrcf(true));
+        if dir == stm32_metapac::i2c::vals::Dir::READ {
+            Ok(hal::I2cSlaveEvent::Read)
+        } else {
+            Ok(hal::I2cSlaveEvent::Write)
+        }
+    }
+
+    fn slave_wait_address_async(&self) -> impl core::future::Future<Output = Result<hal::I2cSlaveEvent, hal::I2cError>> + Send {
+        self.wait_address_async_interrupt()
+    }
+
+    fn slave_read(&self, data: &mut [u8]) -> Result<(), hal::I2cError> {
+        for i in data {
+            while !self.port.isr().read().rxne() && !self.port.isr().read().stopf() {}
+            if self.port.isr().read().stopf() {
+                self.port.icr().write(|v| v.set_stopcf(true));
+                return Err(hal::I2cError::BusError);
+            }
+            *i = self.port.rxdr().read().rxdata();
+        }
+        while !self.port.isr().read().stopf() {}
+        self.port.icr().write(|v| v.set_stopcf(true));
+        Ok(())
+    }
+
+    fn slave_read_async(&self, data: &mut [u8]) -> impl core::future::Future<Output = Result<(), hal::I2cError>> + Send {
+        self.read_async_slave(data)
+    }
+
+    fn slave_write(&self, data: &[u8]) -> Result<(), hal::I2cError> {
+        for &byte in data {
+            while !self.port.isr().read().txis() && !self.port.isr().read().stopf() {}
+            if self.port.isr().read().stopf() {
+                self.port.icr().write(|v| v.set_stopcf(true));
+                return Err(hal::I2cError::BusError);
+            }
+            self.port.txdr().write(|v| v.set_txdata(byte));
+        }
+        while !self.port.isr().read().stopf() {}
+        self.port.icr().write(|v| v.set_stopcf(true));
+        Ok(())
+    }
+
+    fn slave_write_async(&self, data: &[u8]) -> impl core::future::Future<Output = Result<(), hal::I2cError>> + Send {
+        self.write_async_slave(data)
+    }
+}
+
+#[interrupt]
+fn I2C1_EV() {
+    handle_i2c_interrupt(1);
+}
+
+#[interrupt]
+fn I2C1_ER() {
+    handle_i2c_interrupt(1);
+}
+
+#[interrupt]
+fn I2C2_EV() {
+    handle_i2c_interrupt(2);
+}
+
+#[interrupt]
+fn I2C2_ER() {
+    handle_i2c_interrupt(2);
+}
+
+#[interrupt]
+fn I2C3_EV() {
+    handle_i2c_interrupt(3);
+}
+
+#[interrupt]
+fn I2C3_ER() {
+    handle_i2c_interrupt(3);
+}
+
+#[interrupt]
+fn I2C4_EV() {
+    handle_i2c_interrupt(4);
+}
+
+#[interrupt]
+fn I2C4_ER() {
+    handle_i2c_interrupt(4);
+}
+
+fn handle_i2c_interrupt(port_num: u8) {
+    let port = port_num_to_i2c(port_num);
+    WAKERS[port_num as usize].wake();
+    port.cr1().modify(|v| {
+        v.set_txie(false);
+        v.set_rxie(false);
+        v.set_tcie(false);
+        v.set_stopie(false);
+        v.set_nackie(false);
+        v.set_addrie(false);
+    });
 }

--- a/tests/i2c.rs
+++ b/tests/i2c.rs
@@ -1,0 +1,90 @@
+#![no_std]
+#![no_main]
+
+#[cfg(feature = "defmt")]
+use defmt_rtt as _;
+use u5_lib as _; // links panic handler
+
+#[embedded_test::tests]
+mod tests {
+    use u5_lib::hal::{I2c, I2cSlave, I2cSlaveEvent};
+    use u5_lib::i2c::I2c as I2cDriver;
+    use u5_lib::hal::I2cFrequency;
+    use u5_lib::gpio::{I2C1_SCL_PB8, I2C1_SDA_PB9, I2C2_SCL_PB13, I2C2_SDA_PB14, GpioPort};
+    use embassy_futures::join::join;
+
+    #[init]
+    fn init() {
+        u5_lib::clock::init_clock(true, u5_lib::clock::ClockFreqs::KernelFreq160Mhz);
+    }
+
+    #[test]
+    async fn test_i2c_host_slave_communication() {
+        // Host: I2C1 with PB8 (SCL) and PB9 (SDA)
+        let host = <I2cDriver as I2c<GpioPort>>::new(I2cFrequency::Freq100khz, I2C1_SDA_PB9, I2C1_SCL_PB8).unwrap();
+
+        // Slave: I2C2 with PB13 (SCL) and PB14 (SDA), Address 0x50
+        let slave = <I2cDriver as I2cSlave<GpioPort>>::new_slave(I2C2_SDA_PB14, I2C2_SCL_PB13, 0x50).unwrap();
+
+        let host_task = async {
+            // Give slave time to start
+            u5_lib::clock::delay_ms(100);
+
+            // Write to slave
+            let write_data = [0xAA, 0xBB, 0xCC, 0xDD];
+            #[cfg(feature = "defmt")]
+            defmt::info!("Host: Writing to slave...");
+            let res = host.write_async(0x50, &write_data).await;
+            #[cfg(feature = "defmt")]
+            defmt::info!("Host: Write result: {:?}", res);
+            res.expect("Host write failed");
+
+            // Read from slave
+            u5_lib::clock::delay_ms(100);
+            let mut read_buf = [0u8; 4];
+            #[cfg(feature = "defmt")]
+            defmt::info!("Host: Reading from slave...");
+            let res = host.read_async(0x50, &mut read_buf).await;
+            #[cfg(feature = "defmt")]
+            defmt::info!("Host: Read result: {:?} data: {:x}", res, read_buf);
+            res.expect("Host read failed");
+            assert_eq!(read_buf, [0x11, 0x22, 0x33, 0x44]);
+        };
+
+        let slave_task = async {
+            // 1. Wait for Host Write
+            #[cfg(feature = "defmt")]
+            defmt::info!("Slave: Waiting for address (expect Write)...");
+            let event = slave.slave_wait_address_async().await.expect("Slave wait_address failed");
+            match event {
+                I2cSlaveEvent::Write => {
+                    let mut rx_buf = [0u8; 4];
+                    slave.slave_read_async(&mut rx_buf).await.expect("Slave read failed");
+                    #[cfg(feature = "defmt")]
+                    defmt::info!("Slave: Received data: {:x}", rx_buf);
+                    assert_eq!(rx_buf, [0xAA, 0xBB, 0xCC, 0xDD]);
+                }
+                I2cSlaveEvent::Read => panic!("Slave expected Write, got Read"),
+            }
+
+            // 2. Wait for Host Read
+            #[cfg(feature = "defmt")]
+            defmt::info!("Slave: Waiting for address (expect Read)...");
+            let event = slave.slave_wait_address_async().await.expect("Slave wait_address failed");
+            match event {
+                I2cSlaveEvent::Read => {
+                    let tx_data = [0x11, 0x22, 0x33, 0x44];
+                    slave.slave_write_async(&tx_data).await.expect("Slave write failed");
+                    #[cfg(feature = "defmt")]
+                    defmt::info!("Slave: Sent data: {:x}", tx_data);
+                }
+                I2cSlaveEvent::Write => panic!("Slave expected Read, got Write"),
+            }
+        };
+
+        join(host_task, slave_task).await;
+        
+        #[cfg(feature = "defmt")]
+        defmt::info!("I2C Host-Slave test passed!");
+    }
+}


### PR DESCRIPTION
- Add I2cSlave trait to hal.rs
- Implement I2cSlave for I2c driver in i2c.rs
- Add async methods for both host and slave I2C using interrupts and AtomicWaker
- Update GPIO pin mappings for I2C1 and I2C2
- Add a new integration test for host-slave I2C communication